### PR TITLE
Remove trailing slash from site root

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -8,7 +8,16 @@ export default function myModule(options) {
 
   this.nuxt.hook("generate:page", async page => {
     const $ = cheerio.load(page.html);
-    let canonical = options.baseUrl + page.route;
+    let canonical = '';
+    
+    if (
+      page.route === '/' &&
+      options.trailingSlashes !== true
+    ) {
+      canonical = options.baseUrl;
+    } else {
+      canonical = options.baseUrl + page.route;
+    }
 
     if (
       options.trailingSlashes == true &&


### PR DESCRIPTION
If trailingSlashes is disabled, the canonical URL for the the root directory shouldn't include a trailing slash.